### PR TITLE
chore(repositories): remove wildfly-swarm

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -11,7 +11,6 @@ locals {
       "camunda-bpm-platform-osgi",
       "camunda-bpm-process-test-coverage",
       "camunda-bpm-swagger",
-      "camunda-bpm-wildfly-swarm",
       "camunda-dmn-xlsx",
       "camunda-external-task-client-spring-boot",
       "camunda-rest-client-spring-boot",


### PR DESCRIPTION
camunda-bpm-wildfly-swarm was moved to the hub org and will be archived

See this issue https://github.com/camunda-community-hub/camunda-bpm-wildfly-swarm/issues/11