### PR TITLE
Fix pre-commit hooks in relation to GitHub security

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.47.0
     hooks:
       - id: terraform_fmt


### PR DESCRIPTION
- pre-commit was unable to install modules because anonymouns git+ssh was disabled on March 15th
- related to https://github.blog/2021-09-01-improving-git-protocol-security-github/