### PR TITLE
chore(terraform): add new repository

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -47,6 +47,7 @@ locals {
       "zeebe-keycloak-interceptor",
       "zeebe-play",
       "zeebe-process-generator",
+      "zeebe-redis-exporter",
       "zeebe-script-worker",
       "zeebe-simple-monitor",
       "zeebe-simple-tasklist",


### PR DESCRIPTION
Onboarding of zeebe-redis-exporter as new repository.

@camunda-community-hub/devrel: according to your documentation this is necessary - and I'm not yet done with only transferring the repo to the camunda-community-hub. If you feel this is an error, please let me know.

Thanks in advance :-)
Gunnar