### PR TITLE
Rename cherry-framework to cherry-runtime

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -36,7 +36,7 @@ locals {
       "spring-zeebe",
       "thymeleaf-feel",
       "zebee-cherry-filestorage",
-      "zeebe-cherry-framework",
+      "zeebe-cherry-runtime",
       "zeebe-cloudevents-router",
       "zeebe-debug-exporter",
       "zeebe-dmn-worker",


### PR DESCRIPTION
The cherry framework project is renamed cherry runtime