### PR TITLE
Update repositories.tf to include camunda-7-to-8-code-conversion

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -67,7 +67,8 @@ locals {
       "camunda-modeler-template-generator",
       "feel-scala-playground",
       "web-modeler-java-client",
-      "camunda-console-client-java"
+      "camunda-console-client-java",
+      "camunda-7-to-8-code-conversion"
     ],
   }
 }


### PR DESCRIPTION
Please include the new project https://github.com/camunda-community-hub/camunda-7-to-8-code-conversion so that we can do proper Maven build/deployments